### PR TITLE
Fix #62: Build foliage binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["aarch64-linux", "aarch64-darwin", "x86_64-linux", "x86_64-darwin"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v13
+
+      - name: Build
+        run: nix build .#packages.${{ matrix.platform }}.default
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: foliage-${{ matrix.platform }}
+          path: ./result
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        run: |
+          for platform in aarch64-linux aarch64-darwin x86_64-linux x86_64-darwin; do
+            mkdir -p artifacts/$platform
+            wget -O artifacts/$platform/foliage https://github.com/${{ github.repository }}/actions/artifacts/foliage-$platform/zip
+            unzip artifacts/$platform/foliage.zip -d artifacts/$platform
+          done
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        run: |
+          for platform in aarch64-linux aarch64-darwin x86_64-linux x86_64-darwin; do
+            asset_path=artifacts/$platform/foliage
+            asset_name=foliage-$platform
+            asset_content_type=application/octet-stream
+            upload_url=${{ steps.create_release.outputs.upload_url }}
+            echo "Uploading $asset_name to $upload_url ..."
+            curl \
+              --header 'Content-Type: $asset_content_type' \
+              --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --data-binary @$asset_path \
+              --upload-file $asset_path \
+              $upload_url?name=$asset_name
+          done


### PR DESCRIPTION
Implemented a GA using Nix for automatic build and publish a GitHub release from the latest `main` branch commit.

Consider using git tags for more controlled versioning and releases.