### PR TITLE
Fix `preferred-versions` format

### DIFF
--- a/app/Foliage/CmdBuild.hs
+++ b/app/Foliage/CmdBuild.hs
@@ -320,8 +320,13 @@ getExtraEntries packageVersions =
           -- Calculate (by applying them chronologically) the effective `VersionRange` for the package group.
           effectiveRanges :: [(UTCTime, VersionRange)]
           effectiveRanges = NE.tail $ NE.scanl applyChangeToRange (posixSecondsToUTCTime 0, anyVersion) deprecationChanges
+
           -- Create a `Tar.Entry` for the package group, its computed `VersionRange` and a timestamp.
-          createTarEntry (ts, effectiveRange) = mkTarEntry (BL.pack $ prettyShow effectiveRange) (IndexPkgPrefs pn) ts
+          createTarEntry (ts, effectiveRange) = mkTarEntry (BL.pack $ prettyShow dep) (IndexPkgPrefs pn) ts
+            where
+              -- Cabal uses `Dependency` to represent preferred versions, cf.
+              -- `parsePreferredVersions`. The (sub)libraries part is ignored.
+              dep = mkDependency pn effectiveRange mainLibSet
    in foldMap generateEntriesForGroup groupedPackageVersions
 
 -- TODO: the functions belows should be moved to Foliage.PreparedPackageVersion


### PR DESCRIPTION
Cabal can not parse the `preferred-versions` format as written by foliage before this PR as the preceding package name is missing, so all deprecations were ignored before this PR. E.g. the `mtl/preferred-versions` file from the Hackage index looks like this:
```
mtl <2.1 || >2.1 && <2.3 || >2.3
```
Relevant links to the Cabal source code:
 - The contents of the `preferred-versions` files are parsed [here](https://github.com/haskell/cabal/blob/cabal-install-v3.10.1.0/cabal-install/src/Distribution/Client/IndexUtils.hs#L611-L627). It is a line-wise format with simple comments, where lines are parsed via the [`Parsec` instance for `Dependency`](https://hackage.haskell.org/package/Cabal-syntax-3.10.1.0/docs/Distribution-Types-Dependency.html#t:Dependency).
 - Sadly, for secure repos, Cabal uses [`parsePreferredVersions`](https://github.com/haskell/cabal/blob/cabal-install-v3.10.1.0/cabal-install/src/Distribution/Client/IndexUtils.hs#L752), which [silently ignores parse errors](https://github.com/haskell/cabal/blob/cabal-install-v3.10.1.0/cabal-install/src/Distribution/Client/IndexUtils.hs#L600). This could be reported upstream, especially as warnings *are* emitted for `RepoLocalNoIndex`.

---

I used this code to create [this repo](https://amesgen.github.io/cabal-repo-override-example/) ([src](https://github.com/amesgen/cabal-repo-override-example/tree/repo)) for https://github.com/haskell/cabal/pull/8997; this can be used to verify that deprecations now work with this PR. 