### PR TITLE
foliage: Force FileInfo

### DIFF
--- a/app/Foliage/HackageSecurity.hs
+++ b/app/Foliage/HackageSecurity.hs
@@ -32,10 +32,14 @@ readJSONSimple fp = do
   p <- makeAbsolute (fromFilePath fp)
   readJSON_NoKeys_NoLayout p
 
+forceFileInfo :: FileInfo -> ()
+forceFileInfo (FileInfo a b) = a `seq` b `seq` ()
+
 computeFileInfoSimple :: FilePath -> IO FileInfo
 computeFileInfoSimple fp = do
   p <- makeAbsolute (fromFilePath fp)
-  computeFileInfo p
+  fi <- computeFileInfo p
+  return $! forceFileInfo fi `seq` fi
 
 createKeys :: FilePath -> IO ()
 createKeys base = do


### PR DESCRIPTION
Unfortunately hackage-security constructs these using lazy bytestrings and they are therefore liable to hold open fds longer than necessary, resulting in fd exhaustion.

Fixes another manifestation of #35.