### PR TITLE
Let curl show errors when something fails

### DIFF
--- a/app/Foliage/FetchURL.hs
+++ b/app/Foliage/FetchURL.hs
@@ -89,6 +89,8 @@ runCurl uri path etagFile = do
     [ "curl"
     , -- Silent or quiet mode. Do not show progress meter or error messages. Makes Curl mute.
       "--silent"
+    , -- ... but still show errors
+      "--show-error"
     , -- Fail fast with no output at all on server errors.
       "--fail"
     , -- If the server reports that the requested page has moved to a different location this


### PR DESCRIPTION
That the tin says. It is useful in cases like [this](https://github.com/input-output-hk/cardano-haskell-packages/actions/runs/6496446989/job/17644133288#step:5:898).