### PR TITLE
Fix webpage revisions

### DIFF
--- a/app/Foliage/CmdBuild.hs
+++ b/app/Foliage/CmdBuild.hs
@@ -113,7 +113,7 @@ buildAction
 
             -- all revised cabal files, with their timestamp
             revcf <- for (zip [1 :: Int ..] cabalFileRevisions) $ \(revNum, (timestamp, path)) -> do
-              copyFileChanged cabalFilePath (outputDir </> "package" </> prettyShow pkgId </> "revision" </> show revNum <.> "cabal")
+              copyFileChanged path (outputDir </> "package" </> prettyShow pkgId </> "revision" </> show revNum <.> "cabal")
               prepareIndexPkgCabal pkgId timestamp path
 
             -- current version of the cabal file (after the revisions, if any)

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: .
 index-state: 2023-09-10T21:31:08Z
-with-compiler: ghc-9.4.7
+with-compiler: ghc-9.4.8
 
 tests: True
 test-show-details: direct

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
         project = pkgs.haskell-nix.cabalProject' {
           src = ./.;
-          compiler-nix-name = "ghc94";
+          compiler-nix-name = "ghc948";
           shell.tools = {
             cabal = "latest";
             hlint = "latest";


### PR DESCRIPTION
This fixes a bug in the website generation that causes revisions to be duplicated.

E.g.
```
λ curl --silent https://chap.intersectmbo.org/package/typed-protocols-0.1.1.0/revision/1.cabal | sha256sum
3c1f4b32b2a61df886f146d6fc819d4ccac16d435dce41db420e055061e614e6  -
λ curl --silent https://chap.intersectmbo.org/package/typed-protocols-0.1.1.0/revision/2.cabal | sha256sum
3c1f4b32b2a61df886f146d6fc819d4ccac16d435dce41db420e055061e614e6  -
λ curl --silent https://chap.intersectmbo.org/package/typed-protocols-0.1.1.0/revision/3.cabal | sha256sum
3c1f4b32b2a61df886f146d6fc819d4ccac16d435dce41db420e055061e614e6  -
```
while
```
λ sha256sum _sources/typed-protocols/0.1.1.0/revisions/*
3afb8cf577e858150eb2fdc89638c4a88987c1fd0d6332db77b1c69928fd207d  _sources/typed-protocols/0.1.1.0/revisions/1.cabal
8776c5b773e667290edc2b367bfdd6630c559181c37dd43ed3fd33e8ea9fbaa3  _sources/typed-protocols/0.1.1.0/revisions/2.cabal
3c1f4b32b2a61df886f146d6fc819d4ccac16d435dce41db420e055061e614e6  _sources/typed-protocols/0.1.1.0/revisions/3.cabal
```
Revision number 3 (the latest) was used in place of 1 and 2.


