### PR TITLE
Use ghc 9.6 to avoid issues on macOS with latest nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
         project = pkgs.haskell-nix.cabalProject' {
           src = ./.;
-          compiler-nix-name = "ghc948";
+          compiler-nix-name = "ghc96";
           shell.tools = {
             cabal = "latest";
             hlint = "latest";


### PR DESCRIPTION
See https://gitlab.haskell.org/ghc/ghc/-/issues/25608